### PR TITLE
Fix category detection in D3 graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     function drawGraph(data) {
       svg.selectAll('*').remove();
 
-      const categories = data.columns.filter(c => c.startsWith('カテゴリ'));
+      const categories = data.columns.filter(c => c.includes('カテゴリ'));
       const counts = {};
       const linksMap = {};
       categories.forEach(c => counts[c] = 0);


### PR DESCRIPTION
## Summary
- fix category detection using `includes` instead of `startsWith`

## Testing
- `git status --short`